### PR TITLE
CSS and layout improvements

### DIFF
--- a/_sass/haacked-theme.scss
+++ b/_sass/haacked-theme.scss
@@ -35,8 +35,7 @@ $table-text-align: left !default;
 $sidebar-width: 300px !default;
 
 // Width of the content area
-$content-width:    800px !default;
-$on-mobile:        600px !default;
+$on-mobile:        800px !default;
 
 @mixin media-query($device) {
   @media screen and (max-width: $device) {

--- a/_sass/haacked-theme/_header.scss
+++ b/_sass/haacked-theme/_header.scss
@@ -50,6 +50,11 @@
 .site-header {
   margin: 16% auto 10% 10%;
   width: 60%;
+
+  @include media-query($on-mobile) {
+    margin: 5% auto 10%;
+    text-align: center;
+  }
 }
 
 .profilepic {
@@ -62,6 +67,10 @@
     display: block;
     margin: 0;
     width: 160px;
+    
+    @include media-query($on-mobile) {
+      margin: 0 auto;
+    }
   }
 }
 

--- a/_sass/haacked-theme/_layout.scss
+++ b/_sass/haacked-theme/_layout.scss
@@ -50,6 +50,15 @@
   }
 }
 
+.site-footer .wrapper,
+.page-content .wrapper {
+  margin-left: 10%;
+
+  @include media-query($on-mobile) {
+    margin-left: auto;
+  }
+}
+
 //
 // Page content
 //


### PR DESCRIPTION
Fix padding for narrow views. 
When the browser is not very wide, the padding between the left side bar and content becomes very small. Here we add a 10% margin to the wrapper (rather than auto) to ensure we have a bit of padding.

Center header content for mobile
Centering the content on mobile should probably look better