### PR TITLE
Fix the suggest edit link

### DIFF
--- a/_includes/comments/comment.html
+++ b/_includes/comments/comment.html
@@ -1,5 +1,5 @@
 <!-- URL for comment on GitHub
-{{ site.github_repo_url | default: site.github.repository_url }}blob/gh-pages/_data/comments/{{ slug }}/{{ comment.id }}.yml
+{{ site.github_repo_url | default: site.github.repository_url }}/blob/gh-pages/_data/comments/{{ slug }}/{{ comment.id }}.yml
 -->
 
 {% if comment.url %}

--- a/_includes/post/edit.html
+++ b/_includes/post/edit.html
@@ -4,4 +4,4 @@
   {% assign path = page.path %}
 {% endif %}
 
-<a href="{{ site.github_repo_url | default: site.github.repository_url }}edit/gh-pages/{{ path }}">suggest edit</a>
+<a href="{{ site.github_repo_url | default: site.github.repository_url }}/edit/gh-pages/{{ path }}">suggest edit</a>


### PR DESCRIPTION
The `site.github.repository_url` property does not have a trailing slash.