### PR TITLE
Another attempt to fix the edit link

### DIFF
--- a/_includes/post/edit.html
+++ b/_includes/post/edit.html
@@ -3,5 +3,7 @@
 {% else %}
   {% assign path = page.path %}
 {% endif %}
+{% assign source_repo_url = site.github_repo_url | default: site.github.repository_url %}
+{% assign source_branch = site.github_source_branch | default: site.github.source.branch | default: 'gh-pages' %}
 
-<a href="{{ site.github_repo_url | default: site.github.repository_url }}/edit/gh-pages/{{ path }}">suggest edit</a>
+<a href="{{ source_repo_url }}/edit/{{ source_branch }}/{{ path }}">suggest edit</a>


### PR DESCRIPTION
Not every GitHub Pages site is served from the gh-branches branch, so this change takes that into account.