### PR TITLE
Use JS to set the current page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,11 +18,7 @@
           {% assign my_page = site.pages | where: "path", path | first %}
           {% if my_page.title or my_page.nav_title %}
           {% assign title = my_page.nav_title | default: my_page.title %}
-          {% if include.page_url == my_page.url %}
-          <li class="current-page">{{ title | escape }}</li>
-          {% else %}
           <li><a class="page-link" href="{{ my_page.url | relative_url }}">{{ title | escape }}</a></li>
-          {% endif %}
           {% endif %}
         {% endfor %}
         {% if site.contact.url %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   {% include_cached head.html %}
 
   <body>
-    <header class="header" class="inner">{% include_cached header.html page_url = page.url %}</header>
+    <header class="header" class="inner">{% include_cached header.html %}</header>
 
     <main class="page-content" aria-label="Content">
       <div class="wrapper">

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -35,4 +35,22 @@ var Haack = (function() {
         return null
       }
   };
-})();
+})()
+
+// This sets the `current-page` css class on the nav link
+// that points to the current page so we can render it differently
+// We do this in JS so that we can cache the header once rather than
+// generate it for every single page.
+Haack.ready(function() {
+  // Set current page on navigation
+  const path = window.location.pathname
+  const currentPageLink = document.querySelector('a[href="' + path + '"]')
+  if (currentPageLink) {
+    const listItem = currentPageLink.parentElement
+    listItem.classList.add('current-page')
+    const span = document.createElement('span')
+    span.innerText = currentPageLink.textContent
+    listItem.appendChild(span)
+    listItem.removeChild(currentPageLink)
+  }
+})


### PR DESCRIPTION
This lets us render the header section the same for every page which improves the caching experience when building the Jekyll site.