### PR TITLE
Add support for tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,6 @@ permalink: /archive/:year/:month/:day/:title/
 paginate: 2 # number of posts per page
 page_group_size: 5 # number of pages to group by in the pagination.
 paginate_path: "/archive/page/:num"
-category_dir: categories
 
 # Front matter defaults
 defaults:

--- a/_includes/post/categories.html
+++ b/_includes/post/categories.html
@@ -1,1 +1,0 @@
-{{ page.categories | join: ', ' }}{{ post.categories | join: ', ' }}

--- a/_includes/post/meta.html
+++ b/_includes/post/meta.html
@@ -3,7 +3,7 @@
     {% assign date_format = site.haackbar.date_format | default: "%b %-d, %Y" %}
     {{ page.date | default:post.date | date: date_format }}
   </time>
-  <span class="tags">{% include post/categories.html %}</span>
+  <span class="tags">{% include post/tags.html %}</span>
   {% if site.comments.enabled and site.comments.show_count == true %}
     {% include post/comments_link.html %}
   {% endif %}

--- a/_includes/post/tags.html
+++ b/_includes/post/tags.html
@@ -1,0 +1,1 @@
+{{ page.tags | join: ', ' }}{{ post.tags | join: ', ' }}

--- a/_includes/post/tags.html
+++ b/_includes/post/tags.html
@@ -1,1 +1,4 @@
-{{ page.tags | join: ', ' }}{{ post.tags | join: ', ' }}
+{% assign tags = page.tags | default: post.tags %}
+{% for tag in tags %}
+  <a href="/tags/#{{ tag }}">{{ tag }}</a> 
+{% endfor %}

--- a/_posts/2016-05-20-my-example-post.md
+++ b/_posts/2016-05-20-my-example-post.md
@@ -1,4 +1,6 @@
 ---
+tags: [sample, demo]
+title: Sample Post
 ---
 
 Eos eu docendi tractatos sapientem, brute option menandri in vix, quando vivendo accommodare te ius. Nec melius fastidii constituam id, viderer theophrastus ad sit, hinc semper periculis cum id. Noluisse postulant assentior est in, no choro sadipscing repudiandae vix. Vis in euismod delenit dignissim. Ex quod nostrum sit, suas decore animal id ius, nobis solet detracto quo te.

--- a/_posts/2016-05-20-super-long-article.md
+++ b/_posts/2016-05-20-super-long-article.md
@@ -1,6 +1,6 @@
 ---
 title: "Some articles are just so long they deserve a really long title to see if things will break well"
-categories: misc
+tags: [sample]
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce bibendum neque eget nunc mattis eu sollicitudin enim tincidunt. Vestibulum lacus tortor, ultricies id dignissim ac, bibendum in velit. Proin convallis mi ac felis pharetra aliquam. Curabitur dignissim accumsan rutrum. In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris. Proin eget nibh a massa vestibulum pretium. Suspendisse eu nisl a ante aliquet bibendum quis a nunc. Praesent varius interdum vehicula. Aenean risus libero, placerat at vestibulum eget, ultricies eu enim. Praesent nulla tortor, malesuada adipiscing adipiscing sollicitudin, adipiscing eget est.

--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -1,6 +1,6 @@
 ---
 title: "This post demonstrates post content styles"
-categories: junk
+tags: [sample, demo]
 author: "Bart Simpson"
 meta: "Springfield"
 ---

--- a/_posts/2016-05-20-welcome-to-jekyll.md
+++ b/_posts/2016-05-20-welcome-to-jekyll.md
@@ -1,4 +1,6 @@
 ---
+title: Welcome
+tags: [sample, intro]
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/_sass/haackbar/_base.scss
+++ b/_sass/haackbar/_base.scss
@@ -244,3 +244,7 @@ table {
     position: absolute;
   }
 }
+
+.tag {
+  display: none;
+}

--- a/assets/pages/tags.md
+++ b/assets/pages/tags.md
@@ -1,0 +1,46 @@
+---
+title: Tags
+permalink: /tags/
+include_nav: false
+---
+
+<script>
+  Haack.ready(() => {
+    let title = document.getElementsByClassName('post-title')
+    if (title) {
+      title[0].style.display = 'none'
+    }
+    let tag = window.location.hash
+    if(tag) {
+        let tagElement = document.getElementById(tag.substring(1))
+        if (tagElement) {
+        tagElement.style.display = 'block'
+        }
+    }
+  })
+</script>
+
+<style>
+  .tag {display: none;}
+</style>
+
+{% assign tags = site.tags %}
+
+{% for tag in tags %}
+  {% assign tagname = tag | first | slugify %}
+<div id="{{ tagname }}" class="tag">
+  <span>Tagged with</span>
+  <h2>{{ tagname }}</h2>
+  {% assign pages = tag[1] %}
+  <ul>
+  {% for page in pages %}
+    <li>
+      <h3>{{ page.title }}</h3>
+      <div>
+        {{ page.excerpt }}
+      </div>
+    </li>
+  {% endfor %}
+  </ul>
+</div>
+{% endfor %}

--- a/assets/pages/tags.md
+++ b/assets/pages/tags.md
@@ -29,10 +29,6 @@ include_nav: false
   })
 </script>
 
-<style>
-  .tag {display: none;}
-</style>
-
 {% assign tags = site.tags %}
 
 {% for tag in tags %}

--- a/assets/pages/tags.md
+++ b/assets/pages/tags.md
@@ -14,8 +14,17 @@ include_nav: false
     if(tag) {
         let tagElement = document.getElementById(tag.substring(1))
         if (tagElement) {
-        tagElement.style.display = 'block'
+          tagElement.style.display = 'block'
         }
+    }
+    else {
+      // Let's just show them all
+      var tags = document.getElementsByClassName('tag')
+      for (var tagElement of tags) {
+        if (tagElement) {
+          tagElement.style.display = 'block'
+        }
+      }
     }
   })
 </script>

--- a/assets/pages/tags.md
+++ b/assets/pages/tags.md
@@ -29,16 +29,13 @@ include_nav: false
 {% for tag in tags %}
   {% assign tagname = tag | first | slugify %}
 <div id="{{ tagname }}" class="tag">
-  <span>Tagged with</span>
+  <span class="meta">Tagged with</span>
   <h2>{{ tagname }}</h2>
-  {% assign pages = tag[1] %}
+  {% assign posts = tag[1] %}
   <ul>
-  {% for page in pages %}
+  {% for post in posts %}
     <li>
-      <h3>{{ page.title }}</h3>
-      <div>
-        {{ page.excerpt }}
-      </div>
+      <h3 class="title"><a href="{{ post.url }}">{{post.title}}</a></h3>
     </li>
   {% endfor %}
   </ul>


### PR DESCRIPTION
Renders a page that lists all tags and all posts for each tag. But, they are hidden by default. The tag to display is passed via the url fragment. If no url fragment is passed, every tag is displayed.

Now the tag for each post actually links somewhere.

It's haacky, but it works.