### PR TITLE
Use Open Sans Condensed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,5 +15,5 @@
 	<script src="{{ '/assets/js/md5.min.js' | relative_url }}" async></script>
   <script src="{{ '/assets/js/comment-box.js' | relative_url }}" async></script>
   {% endif %}
-  <link href="https://fonts.googleapis.com/css?family=Mate" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Mate|Open+Sans+Condensed" rel="stylesheet">
 </head>

--- a/_sass/haackbar.scss
+++ b/_sass/haackbar.scss
@@ -5,7 +5,7 @@
 $header-background-color: #652a2b !default;
 $brand-color:      #d2691e !default;
 $post-font-family: 'Mate', Georgia, Cambria, "Times New Roman", Times, serif !default;
-$base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
+$base-font-family: "Open Sans Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $code-font-family: Consolas, Menlo, Monaco, 'Andale Mono', 'lucida console' !default;
 $baseurl: '' !default;
 


### PR DESCRIPTION
Currently the site uses different fonts on Mac and Windows because Windows doesn't have Helvetica Neue. This ensures the same font is used for both platforms.