### PR TITLE
Relative url for favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="{{ '/favicon.ico' | relative_url }}">
   {% if site.twitter_username %}{% include twitter_card.html %}{% endif %}
   {% seo %}
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">


### PR DESCRIPTION
In those cases that the site is not on the root, like <username>.github.io/blog/, the favicon does not render properly. I added the relative_url param to work as the other sources.