### PR TITLE
Fix post redirection for relative urls

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,7 +14,7 @@ layout: default
       {% for post in paginator.posts %}
       {% unless post.redirect %}
       <header class="post-header">
-        <h1 class="post-title p-name" itemprop="name headline"><a href="{{ post.url }}">{{ post.title | escape }}</a></h1>
+        <h1 class="post-title p-name" itemprop="name headline"><a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></h1>
         {% include post/meta.html %}
       </header>
     
@@ -22,10 +22,10 @@ layout: default
         {% if site.show_excerpts %}
           <div class="excerpt">
             {% if post.excerpt_image %}
-            <img src="{{post.excerpt_image }}" />
+            <img src="{{ post.excerpt_image }}" />
             {% endif %}
             {{ post.excerpt }}
-            <a href="{{ post.url }}" class="read-more">Read More</a>
+            <a href="{{ post.url | relative_url }}" class="read-more">Read More</a>
           </div>
         {% else %}
           {{ post.content }}


### PR DESCRIPTION
As the other fix, in this one when my site is not on the root, the links are broken. Adding just the relative_url param fixes it.